### PR TITLE
Add reset fields feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
+# Streamlit Recipe Bot
 
+This app provides advanced and simple search tools for finding recipes and a cookbook library interface.
+
+## Reset Fields Feature
+
+The Advanced Search page now includes a **Reset Fields** button to quickly restore all search inputs to their default values.

--- a/constants.py
+++ b/constants.py
@@ -443,6 +443,7 @@ class LogMsg(StrEnum):
     ADV_SEARCH_PROCESSED = (
         "Processed results. HTML length: {html_len}, Mapping keys: {map_keys}"
     )
+    ADV_SEARCH_RESET_CLICKED = "Advanced search reset button clicked."
     SIMPLE_SEARCH_CLICKED = "Simple search button clicked."
     SIMPLE_SEARCH_PARAMS = (
         "Calling query_top_k for simple search with params: {params_json}"

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -14,6 +14,7 @@ class UiText(StrEnum):
 
     WARNING_NO_INGREDIENTS_FROM_IMAGE = "No ingredients found."
     SUCCESS_INGREDIENTS_FROM_IMAGE = "✓ {count} Ingredients added"
+    SUCCESS_FIELDS_RESET = "✓ Fields reset to defaults"
     SPINNER_PROCESSING_IMAGE = "Detecting ingredients…"
     LABEL_FILE_INPUT = "…or upload an image"
     LABEL_CAMERA_INPUT = "Take a picture"
@@ -115,6 +116,7 @@ class UiText(StrEnum):
     BUTTON_SAVE_PROFILE = "Save Current Settings"
     BUTTON_LOAD_PROFILE = "Load Most Recent Profile"
     BUTTON_SEARCH_RECIPES = "Search Recipes"
+    BUTTON_RESET_FIELDS = "Reset Fields"
     MARKDOWN_MATCHING_RECIPES = "##### Matching Recipes Table"
     MARKDOWN_SELECT_RECIPE = "##### Select Recipe for Details"
     MARKDOWN_RECIPE_DETAILS = "##### Recipe Details"

--- a/ui_pages/advanced_search.py
+++ b/ui_pages/advanced_search.py
@@ -624,6 +624,62 @@ def render_advanced_search_page(
             logging.INFO, LogMsg.SOURCES_SET_ALL, source_count=len(valid_sources)
         )
 
+    def reset_fields_action():
+        """Reset advanced search inputs to defaults."""
+        log_with_payload(logging.INFO, LogMsg.ADV_SEARCH_RESET_CLICKED)
+        defaults = config.defaults
+
+        st.session_state[SessionStateKeys.LOADED_INGREDIENTS_TEXT] = defaults.ingredients_text
+        st.session_state[SessionStateKeys.ADV_INGREDIENTS_INPUT] = defaults.ingredients_text
+        st.session_state[SessionStateKeys.LOADED_MUST_USE_TEXT] = defaults.must_use_text
+        st.session_state[SessionStateKeys.ADV_MUST_USE_INPUT] = defaults.must_use_text
+        st.session_state[SessionStateKeys.LOADED_EXCLUDED_TEXT] = defaults.excluded_text
+        st.session_state[SessionStateKeys.ADV_EXCLUDED_INPUT] = defaults.excluded_text
+        st.session_state[SessionStateKeys.LOADED_KEYWORDS_INCLUDE] = defaults.keywords_include
+        st.session_state[SessionStateKeys.ADV_KEYWORDS_INCLUDE_INPUT] = defaults.keywords_include
+        st.session_state[SessionStateKeys.LOADED_KEYWORDS_EXCLUDE] = defaults.keywords_exclude
+        st.session_state[SessionStateKeys.ADV_KEYWORDS_EXCLUDE_INPUT] = defaults.keywords_exclude
+        st.session_state[SessionStateKeys.LOADED_MIN_ING_MATCHES] = defaults.min_ing_matches
+        st.session_state[SessionStateKeys.ADV_MIN_ING_MATCHES_INPUT] = defaults.min_ing_matches
+        st.session_state[SessionStateKeys.LOADED_MAX_STEPS] = defaults.max_steps
+        st.session_state[SessionStateKeys.ADV_MAX_STEPS_INPUT] = defaults.max_steps
+        st.session_state[SessionStateKeys.LOADED_TAG_FILTER_MODE] = default_tag_filter_mode_enum
+        st.session_state[SessionStateKeys.ADV_TAG_FILTER_MODE_INPUT] = default_tag_filter_mode_enum
+        st.session_state[SessionStateKeys.LOADED_USER_COVERAGE] = defaults.user_coverage * 100.0
+        st.session_state[SessionStateKeys.ADV_USER_COVERAGE_SLIDER] = defaults.user_coverage * 100.0
+        st.session_state[SessionStateKeys.LOADED_RECIPE_COVERAGE] = defaults.recipe_coverage * 100.0
+        st.session_state[SessionStateKeys.ADV_RECIPE_COVERAGE_SLIDER] = defaults.recipe_coverage * 100.0
+
+        for loaded_key, widget_key in [
+            (SessionStateKeys.LOADED_COURSE_FILTER, SessionStateKeys.ADV_COURSE_FILTER_INPUT),
+            (SessionStateKeys.LOADED_MAIN_ING_FILTER, SessionStateKeys.ADV_MAIN_ING_FILTER_INPUT),
+            (SessionStateKeys.LOADED_DISH_TYPE_FILTER, SessionStateKeys.ADV_DISH_TYPE_FILTER_INPUT),
+            (SessionStateKeys.LOADED_RECIPE_TYPE_FILTER, SessionStateKeys.ADV_RECIPE_TYPE_FILTER_INPUT),
+            (SessionStateKeys.LOADED_CUISINE_FILTER, SessionStateKeys.ADV_CUISINE_FILTER_INPUT),
+            (SessionStateKeys.LOADED_EXCLUDE_COURSE_FILTER, SessionStateKeys.ADV_EXCLUDE_COURSE_FILTER_INPUT),
+            (SessionStateKeys.LOADED_EXCLUDE_MAIN_ING_FILTER, SessionStateKeys.ADV_EXCLUDE_MAIN_ING_FILTER_INPUT),
+            (SessionStateKeys.LOADED_EXCLUDE_DISH_TYPE_FILTER, SessionStateKeys.ADV_EXCLUDE_DISH_TYPE_FILTER_INPUT),
+            (SessionStateKeys.LOADED_EXCLUDE_RECIPE_TYPE_FILTER, SessionStateKeys.ADV_EXCLUDE_RECIPE_TYPE_FILTER_INPUT),
+            (SessionStateKeys.LOADED_EXCLUDE_CUISINE_FILTER, SessionStateKeys.ADV_EXCLUDE_CUISINE_FILTER_INPUT),
+        ]:
+            st.session_state[loaded_key] = []
+            st.session_state[widget_key] = []
+
+        all_sources_list = [
+            s
+            for s in st.session_state.get(SessionStateKeys.ALL_SOURCES_LIST, [])
+            if s != UiText.ERROR_SOURCES_DISPLAY
+        ]
+        st.session_state[SessionStateKeys.LOADED_SOURCES] = all_sources_list
+        st.session_state[SessionStateKeys.ADV_SOURCE_SELECTOR] = all_sources_list
+
+        st.session_state[SessionStateKeys.ADVANCED_SEARCH_RESULTS_HTML] = defaults.profile_message
+        st.session_state[SessionStateKeys.ADVANCED_SEARCH_MAPPING] = {}
+        st.session_state[SessionStateKeys.ADVANCED_SELECTED_RECIPE_LABEL] = None
+        st.session_state[SessionStateKeys.ADVANCED_SEARCH_RESULTS_DF] = None
+
+        st.success(UiText.SUCCESS_FIELDS_RESET)
+
     def update_selected_recipe():
         """Callback function for the recipe selector dropdown."""
 
@@ -904,12 +960,20 @@ def render_advanced_search_page(
                 unsafe_allow_html=True,
             )
 
-        st.button(
-            UiText.BUTTON_SEARCH_RECIPES,
-            on_click=run_advanced_search,
-            type="primary",
-            use_container_width=True,
-        )
+        search_col_btn, reset_col_btn = st.columns(2)
+        with search_col_btn:
+            st.button(
+                UiText.BUTTON_SEARCH_RECIPES,
+                on_click=run_advanced_search,
+                type="primary",
+                use_container_width=True,
+            )
+        with reset_col_btn:
+            st.button(
+                UiText.BUTTON_RESET_FIELDS,
+                on_click=reset_fields_action,
+                use_container_width=True,
+            )
     with results_col:
         st.subheader(UiText.SUBHEADER_RESULTS)
 

--- a/ui_pages/advanced_search.py
+++ b/ui_pages/advanced_search.py
@@ -630,25 +630,25 @@ def render_advanced_search_page(
         defaults = config.defaults
 
         st.session_state[SessionStateKeys.LOADED_INGREDIENTS_TEXT] = defaults.ingredients_text
-        st.session_state[SessionStateKeys.ADV_INGREDIENTS_INPUT] = defaults.ingredients_text
+        st.session_state.pop(SessionStateKeys.ADV_INGREDIENTS_INPUT, None)
         st.session_state[SessionStateKeys.LOADED_MUST_USE_TEXT] = defaults.must_use_text
-        st.session_state[SessionStateKeys.ADV_MUST_USE_INPUT] = defaults.must_use_text
+        st.session_state.pop(SessionStateKeys.ADV_MUST_USE_INPUT, None)
         st.session_state[SessionStateKeys.LOADED_EXCLUDED_TEXT] = defaults.excluded_text
-        st.session_state[SessionStateKeys.ADV_EXCLUDED_INPUT] = defaults.excluded_text
+        st.session_state.pop(SessionStateKeys.ADV_EXCLUDED_INPUT, None)
         st.session_state[SessionStateKeys.LOADED_KEYWORDS_INCLUDE] = defaults.keywords_include
-        st.session_state[SessionStateKeys.ADV_KEYWORDS_INCLUDE_INPUT] = defaults.keywords_include
+        st.session_state.pop(SessionStateKeys.ADV_KEYWORDS_INCLUDE_INPUT, None)
         st.session_state[SessionStateKeys.LOADED_KEYWORDS_EXCLUDE] = defaults.keywords_exclude
-        st.session_state[SessionStateKeys.ADV_KEYWORDS_EXCLUDE_INPUT] = defaults.keywords_exclude
+        st.session_state.pop(SessionStateKeys.ADV_KEYWORDS_EXCLUDE_INPUT, None)
         st.session_state[SessionStateKeys.LOADED_MIN_ING_MATCHES] = defaults.min_ing_matches
-        st.session_state[SessionStateKeys.ADV_MIN_ING_MATCHES_INPUT] = defaults.min_ing_matches
+        st.session_state.pop(SessionStateKeys.ADV_MIN_ING_MATCHES_INPUT, None)
         st.session_state[SessionStateKeys.LOADED_MAX_STEPS] = defaults.max_steps
-        st.session_state[SessionStateKeys.ADV_MAX_STEPS_INPUT] = defaults.max_steps
+        st.session_state.pop(SessionStateKeys.ADV_MAX_STEPS_INPUT, None)
         st.session_state[SessionStateKeys.LOADED_TAG_FILTER_MODE] = default_tag_filter_mode_enum
-        st.session_state[SessionStateKeys.ADV_TAG_FILTER_MODE_INPUT] = default_tag_filter_mode_enum
+        st.session_state.pop(SessionStateKeys.ADV_TAG_FILTER_MODE_INPUT, None)
         st.session_state[SessionStateKeys.LOADED_USER_COVERAGE] = defaults.user_coverage * 100.0
-        st.session_state[SessionStateKeys.ADV_USER_COVERAGE_SLIDER] = defaults.user_coverage * 100.0
+        st.session_state.pop(SessionStateKeys.ADV_USER_COVERAGE_SLIDER, None)
         st.session_state[SessionStateKeys.LOADED_RECIPE_COVERAGE] = defaults.recipe_coverage * 100.0
-        st.session_state[SessionStateKeys.ADV_RECIPE_COVERAGE_SLIDER] = defaults.recipe_coverage * 100.0
+        st.session_state.pop(SessionStateKeys.ADV_RECIPE_COVERAGE_SLIDER, None)
 
         for loaded_key, widget_key in [
             (SessionStateKeys.LOADED_COURSE_FILTER, SessionStateKeys.ADV_COURSE_FILTER_INPUT),
@@ -663,7 +663,7 @@ def render_advanced_search_page(
             (SessionStateKeys.LOADED_EXCLUDE_CUISINE_FILTER, SessionStateKeys.ADV_EXCLUDE_CUISINE_FILTER_INPUT),
         ]:
             st.session_state[loaded_key] = []
-            st.session_state[widget_key] = []
+            st.session_state.pop(widget_key, None)
 
         all_sources_list = [
             s
@@ -671,7 +671,7 @@ def render_advanced_search_page(
             if s != UiText.ERROR_SOURCES_DISPLAY
         ]
         st.session_state[SessionStateKeys.LOADED_SOURCES] = all_sources_list
-        st.session_state[SessionStateKeys.ADV_SOURCE_SELECTOR] = all_sources_list
+        st.session_state.pop(SessionStateKeys.ADV_SOURCE_SELECTOR, None)
 
         st.session_state[SessionStateKeys.ADVANCED_SEARCH_RESULTS_HTML] = defaults.profile_message
         st.session_state[SessionStateKeys.ADVANCED_SEARCH_MAPPING] = {}


### PR DESCRIPTION
## Summary
- add **Reset Fields** action in Advanced Search UI
- support translations for log and UI text
- document the new feature in README

## Testing
- `python -m py_compile streamlit_app.py ui_pages/advanced_search.py ui_helpers.py constants.py session_state.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4e32119c8325a3516d13b772e071