### PR TITLE
Add Mistral docs page

### DIFF
--- a/chat_agent.py
+++ b/chat_agent.py
@@ -1,0 +1,103 @@
+import logging
+
+from typing import Any
+
+import numpy as np
+from mistralai.models import SystemMessage, UserMessage
+
+from config import AppConfig
+from constants import ModelName, ToolText, ToolCall, AgentText, SearchLimit, TagFilterMode
+from models import RecipeSearchArgs, RecipeRankArgs
+from mistralai.models.function import Function
+from mistralai.models.tool import Tool, ToolTypes
+from query_top_k import query_top_k
+from mistral_utils import embeddings_create, chat_complete
+
+
+RESULT_LIMIT = SearchLimit.RESULTS
+
+
+
+SEARCH_TOOL = Tool(
+    type="function",
+    function=Function(
+        name=ToolCall.SEARCH_RECIPES,
+        description=ToolText.SEARCH_DESC,
+        parameters=RecipeSearchArgs.model_json_schema(),
+    ),
+)
+
+RANK_TOOL = Tool(
+    type="function",
+    function=Function(
+        name=ToolCall.RANK_RECIPES,
+        description=ToolText.RANK_DESC,
+        parameters=RecipeRankArgs.model_json_schema(),
+    ),
+)
+
+
+def search_and_rerank(query: str, config: AppConfig, sources: list[str]) -> list[dict[str, Any]]:
+    """Search recipes using query_top_k and rerank with embeddings and LLM."""
+    results = query_top_k(
+        user_ingredients=[],
+        tag_filters={},
+        excluded_tags={},
+        min_ing_matches=0,
+        forbidden_ingredients=[],
+        must_use=[],
+        tag_filter_mode=TagFilterMode.AND,
+        max_steps=0,
+        user_coverage_req=0.0,
+        recipe_coverage_req=0.0,
+        keywords_to_include=query.split(),
+        keywords_to_exclude=[],
+        sources=sources,
+    )
+
+    if not results:
+        return []
+
+    titles = [query] + [r.get("title", "") for r in results]
+    try:
+        resp = embeddings_create(config, inputs=titles, model=ModelName.EMBED_BASE)
+    except Exception as e:
+        logging.error("Embedding request failed: %s", e)
+        return results[:RESULT_LIMIT]
+
+    embeds = [d.embedding for d in resp.data]
+    query_vec = np.array(embeds[0])
+    recipe_vecs = np.array(embeds[1:])
+    denom = np.linalg.norm(recipe_vecs, axis=1) * np.linalg.norm(query_vec)
+    sims = recipe_vecs @ query_vec / (denom + 1e-10)
+    ranked = [r for _, r in sorted(zip(sims, results), key=lambda p: p[0], reverse=True)]
+
+    items = "\n".join(
+        f"{i + 1}. {r.get('url', '')}" for i, r in enumerate(ranked[:RESULT_LIMIT])
+    )
+    messages = [
+        SystemMessage(content=AgentText.RERANK_SYSTEM),
+        UserMessage(content=AgentText.RERANK_USER.format(query=query) + "\n" + items),
+    ]
+    try:
+        resp_rank = chat_complete(
+            config,
+            messages=messages,
+            model=ModelName.CHAT_SMALL,
+            tools=[RANK_TOOL],
+            tool_choice=ToolCall.RANK_RECIPES,
+            temperature=0.2,
+        )
+        ordered: list[dict[str, Any]] = []
+        if resp_rank.choices[0].message.tool_calls:
+            call = resp_rank.choices[0].message.tool_calls[0]
+            args = RecipeRankArgs.model_validate_json(call.function.arguments)
+            for idx in args.order:
+                if 1 <= idx <= len(ranked):
+                    ordered.append(ranked[idx - 1])
+        if ordered:
+            ranked = ordered
+    except Exception as e:
+        logging.error("LLM ranking failed: %s", e)
+
+    return ranked[:RESULT_LIMIT]

--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 from enum import StrEnum, IntEnum
+from mistralai.models.function import Function
+from mistralai.models.tool import Tool, ToolTypes
 
 
 class FileExt(StrEnum):
@@ -513,11 +515,51 @@ class UserPrompt(StrEnum):
 
 class ModelName(StrEnum):
     VISION = "mistral-small-2503"
+    CHAT_SMALL = "mistral-small-latest"
+    EMBED_BASE = "mistral-embed"
+
+
+class ToolText(StrEnum):
+    """Text for tool descriptions and parameters."""
+
+    SEARCH_DESC = "Search and rank recipes by keywords"
+    QUERY_DESC = "Keywords for searching recipes"
+    RANK_DESC = "Return a new ordering for the given recipes"
+    ORDER_PARAM = "New ordering of recipe numbers"
+
+
+class ToolCall(StrEnum):
+    SEARCH_RECIPES = "search_recipes"
+    RANK_RECIPES = "rank_recipes"
+
+
+class AgentText(StrEnum):
+    """Prompts for agentic reranking."""
+
+    RERANK_SYSTEM = (
+        "You are an expert chef helping choose recipes for the user."
+    )
+    RERANK_USER = (
+        "Given the user's intent '{query}', order the following recipe URLs by relevance."
+    )
+
+    CHATBOT_SYSTEM = (
+        "You are RecipeBot, an expert cooking assistant. Hold a friendly conversation to"
+        " understand the user's preferences, ingredients, and any images they upload."
+        " When the user is ready, call the search tool with an appropriate keyword"
+        " query."
+        " After the search tool returns a list of recipes, rank them based on how well"
+        " they match the user's intent and respond with your top picks."
+    )
 
 
 class CacheLimit(IntEnum):
     MAX_TOKENS = 4096
     MAX_IMAGES = 8
+
+
+class SearchLimit(IntEnum):
+    RESULTS = 5
 
 
 class Suffix(StrEnum):

--- a/mistral_utils.py
+++ b/mistral_utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from diskcache import Cache
+from functools import lru_cache
+from mistralai import Mistral
+
+from config import AppConfig
+from constants import ModelName
+
+_cache = Cache("mistral_cache")
+
+@lru_cache(maxsize=1)
+def get_client(api_key: str) -> Mistral:
+    """Return a cached Mistral client."""
+    return Mistral(api_key=api_key)
+
+
+def _cache_key(prefix: str, payload: Any) -> str:
+    try:
+        body = json.dumps(payload, sort_keys=True)
+    except TypeError:
+        body = str(payload)
+    return f"{prefix}:{body}"
+
+
+def chat_complete(cfg: AppConfig, *, messages: list, model: ModelName, **kwargs: Any) -> Any:
+    """Cached wrapper around Mistral.chat.complete."""
+    client = get_client(cfg.api_key)
+    key = _cache_key("chat", {"model": model, "messages": [getattr(m, "model_dump", lambda: m)() for m in messages], **kwargs})
+    if cached := _cache.get(key):
+        return cached
+    resp = client.chat.complete(model=model, messages=messages, **kwargs)
+    try:
+        _cache.set(key, resp)
+    except Exception:
+        pass
+    return resp
+
+
+def embeddings_create(cfg: AppConfig, *, inputs: Iterable[str], model: ModelName) -> Any:
+    """Cached wrapper around Mistral.embeddings.create."""
+    client = get_client(cfg.api_key)
+    key = _cache_key("embed", {"model": model, "inputs": list(inputs)})
+    if cached := _cache.get(key):
+        return cached
+    resp = client.embeddings.create(model=model, inputs=list(inputs))
+    try:
+        _cache.set(key, resp)
+    except Exception:
+        pass
+    return resp

--- a/models.py
+++ b/models.py
@@ -39,3 +39,15 @@ class SaveProfileRequest(BaseModel):
 class LoadProfileRequest(BaseModel):
     username: str
     timestamp: str | None = None
+
+
+class RecipeSearchArgs(BaseModel):
+    """Arguments for the recipe search tool."""
+
+    query: str
+
+
+class RecipeRankArgs(BaseModel):
+    """Arguments returned by the ranking tool."""
+
+    order: list[int]

--- a/session_state.py
+++ b/session_state.py
@@ -63,6 +63,8 @@ class SessionStateKeys(StrEnum):
     SIMPLE_QUERY_INPUT = "widget_simple_query"
     LIBRARY_BOOK_SELECTOR = "widget_library_book_selector"
 
+    CHAT_HISTORY = "chat_history"
+
     ALL_SOURCES_LIST = "all_sources_list"
     LIBRARY_BOOK_MAPPING = "library_book_mapping"
     PROFILE_STATUS_MESSAGE = "profile_status_message"

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,10 +2,11 @@ import logging
 from datetime import datetime
 
 import streamlit as st
+from mistralai.models import AssistantMessage, SystemMessage
 
 from cache_manager import fetch_db_last_updated
 from config import CONFIG
-from constants import FormatStrings, LogMsg
+from constants import FormatStrings, LogMsg, AgentText
 from db_utils import init_profile_db, fetch_sources_cached
 from gdrive_utils import download_essential_files, list_drive_books_cached
 from log_utils import ErrorPayload, log_with_payload
@@ -14,6 +15,8 @@ from ui_helpers import UiText
 from ui_pages.advanced_search import render_advanced_search_page
 from ui_pages.library import render_library_page
 from ui_pages.simple_search import render_simple_search_page
+from ui_pages.chatbot import render_chatbot_page
+from ui_pages.mistral_doc import render_mistral_doc_page
 
 st.set_page_config(layout="wide", page_title=UiText.PAGE_TITLE)
 
@@ -134,6 +137,10 @@ def initialize_session_state():
         SessionStateKeys.LOADED_RECIPE_COVERAGE: defaults.recipe_coverage * 100.0,
         SessionStateKeys.LOADED_SOURCES: default_sources,
         SessionStateKeys.PROFILE_STATUS_MESSAGE: defaults.profile_message,
+        SessionStateKeys.CHAT_HISTORY: [
+            SystemMessage(content=AgentText.CHATBOT_SYSTEM),
+            AssistantMessage(content=UiText.CHAT_INIT_MESSAGE),
+        ],
     }
 
     for key, default_value in state_initializer.items():
@@ -149,6 +156,8 @@ page_options = [
     UiText.TAB_ADVANCED,
     UiText.TAB_SIMPLE,
     UiText.TAB_LIBRARY,
+    UiText.TAB_CHAT,
+    UiText.TAB_MISTRAL,
 ]
 
 st.sidebar.radio(
@@ -176,6 +185,18 @@ elif st.session_state[SessionStateKeys.SELECTED_PAGE] == UiText.TAB_SIMPLE:
 
 elif st.session_state[SessionStateKeys.SELECTED_PAGE] == UiText.TAB_LIBRARY:
     render_library_page(
+        st,
+        CONFIG,
+    )
+
+elif st.session_state[SessionStateKeys.SELECTED_PAGE] == UiText.TAB_CHAT:
+    render_chatbot_page(
+        st,
+        CONFIG,
+    )
+
+elif st.session_state[SessionStateKeys.SELECTED_PAGE] == UiText.TAB_MISTRAL:
+    render_mistral_doc_page(
         st,
         CONFIG,
     )

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1,0 +1,74 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+import streamlit as st
+
+st.secrets._secrets = {}
+
+import sys
+from types import ModuleType
+
+dummy = ModuleType('query_top_k')
+dummy.query_top_k = lambda **kwargs: []
+sys.modules['query_top_k'] = dummy
+
+
+from config import AppConfig
+import chat_agent
+from chat_agent import search_and_rerank
+
+
+class DummyEmb:
+    def __init__(self, embedding):
+        self.embedding = embedding
+
+
+class DummyEmbedResp:
+    def __init__(self, data):
+        self.data = [DummyEmb(e) for e in data]
+
+
+class DummyChatResp:
+    def __init__(self, order):
+        call = SimpleNamespace(
+            id="1",
+            function=SimpleNamespace(arguments=json.dumps({"order": order})),
+        )
+        msg = SimpleNamespace(tool_calls=[call])
+        choice = SimpleNamespace(message=msg)
+        self.choices = [choice]
+
+
+def test_search_and_rerank_uses_llm_order(monkeypatch):
+    cfg = AppConfig(api_key="test")
+
+    sample_results = [
+        {"title": "A", "url": "u1"},
+        {"title": "B", "url": "u2"},
+        {"title": "C", "url": "u3"},
+    ]
+
+    monkeypatch.setattr(
+        "chat_agent.query_top_k",
+        lambda **kwargs: sample_results,
+    )
+
+    def fake_embeddings_create(*args, **kwargs):
+        return DummyEmbedResp(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [0.0, 0.5],
+                [1.0, 0.0],
+            ]
+        )
+
+    monkeypatch.setattr("chat_agent.embeddings_create", fake_embeddings_create)
+    monkeypatch.setattr(
+        "chat_agent.chat_complete", lambda *a, **k: DummyChatResp([3, 1, 2])
+    )
+
+    ordered = search_and_rerank("chicken", cfg, ["s1"])
+    assert [r["title"] for r in ordered] == ["B", "C", "A"]
+

--- a/tests/test_chatbot_page.py
+++ b/tests/test_chatbot_page.py
@@ -1,0 +1,116 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+import streamlit as st
+
+st.secrets._secrets = {}
+
+import sys
+from types import ModuleType
+
+dummy = ModuleType('query_top_k')
+dummy.query_top_k = lambda **kwargs: []
+sys.modules['query_top_k'] = dummy
+
+
+from config import AppConfig
+from session_state import SessionStateKeys
+from ui_pages.chatbot import render_chatbot_page
+
+
+class FakeExpander:
+    def __init__(self):
+        self.markdowns = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def markdown(self, text):
+        self.markdowns.append(text)
+
+
+class FakeSidebar:
+    def __init__(self, parent):
+        self.parent = parent
+        self.expanders = []
+
+    def expander(self, title, expanded=True):
+        exp = FakeExpander()
+        self.expanders.append(exp)
+        return exp
+
+
+class FakeChatMessage:
+    def __init__(self, store, role):
+        self.store = store
+        self.role = role
+
+    def markdown(self, content):
+        self.store.append((self.role, content))
+
+
+class FakeStreamlit:
+    def __init__(self, user_input=""):
+        self.input = user_input
+        self.session_state = {}
+        self.sidebar = FakeSidebar(self)
+        self.messages = []
+
+    def header(self, text):
+        pass
+
+    def info(self, text):
+        pass
+
+    def chat_input(self, placeholder):
+        return self.input
+
+    def file_uploader(self, *a, **k):
+        return []
+
+    def chat_message(self, role):
+        return FakeChatMessage(self.messages, role)
+
+    def markdown(self, text):
+        if self.sidebar.expanders:
+            self.sidebar.expanders[-1].markdown(text)
+
+    def error(self, text):
+        self.messages.append(("error", text))
+
+
+def test_render_chatbot_page_flow(monkeypatch):
+    cfg = AppConfig(api_key="test")
+    st = FakeStreamlit(user_input="chicken")
+    st.session_state[SessionStateKeys.ALL_SOURCES_LIST] = ["s1"]
+
+    def fake_chat_complete(*args, **kwargs):
+        if fake_chat_complete.calls == 0:
+            fake_chat_complete.calls += 1
+            call = SimpleNamespace(
+                id="1",
+                function=SimpleNamespace(arguments=json.dumps({"query": "chicken"})),
+            )
+            msg = SimpleNamespace(content="searching", tool_calls=[call])
+        else:
+            msg = SimpleNamespace(content="done", tool_calls=None)
+        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+    fake_chat_complete.calls = 0
+
+    monkeypatch.setattr("ui_pages.chatbot.chat_complete", fake_chat_complete)
+    monkeypatch.setattr(
+        "ui_pages.chatbot.search_and_rerank",
+        lambda q, cfg, sources: [{"title": "R1", "url": "url1"}],
+    )
+
+    render_chatbot_page(st, cfg)
+
+    history = st.session_state[SessionStateKeys.CHAT_HISTORY]
+    assert history[-1].content == "done"
+    assert st.sidebar.expanders[-1].markdowns == ["- [R1](url1)"]
+

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -25,6 +25,8 @@ class UiText(StrEnum):
     TAB_ADVANCED = "Advanced Search"
     TAB_SIMPLE = "Simple Search"
     TAB_LIBRARY = "Library"
+    TAB_CHAT = "Chatbot"
+    TAB_MISTRAL = "Mistral Docs"
     SIDEBAR_PAGE_SELECT = "Select Page"
     ABOUT_MARKDOWN = """
         # Recipe Finder
@@ -71,6 +73,8 @@ class UiText(StrEnum):
 
         - **Library Tab:**
           Browse cookbooks downloaded from Google Drive. Requires `ebook-convert` (from Calibre) to be installed and in the PATH for non-PDF files.
+        - **Chatbot Tab:**
+          Chat with an assistant that can understand free-form requests like "I feel like a summery treat" or lists of ingredients. It may ask follow-up questions and then search for suitable recipes.
         """
 
     HEADER_ADVANCED_SEARCH = "Advanced Recipe Search"
@@ -166,6 +170,54 @@ class UiText(StrEnum):
     WARN_NO_BOOKS_FOUND = "No books found in the configured Google Drive folder."
     SELECTBOX_LABEL_BOOK = "Choose a book"
     BUTTON_REFRESH_BOOKS = "Refresh Book List"
+    HEADER_CHAT = "Chatbot Search"
+    CHAT_PLACEHOLDER = "Ask me for recipe ideas..."
+    CHAT_INIT_MESSAGE = "Hello! Tell me what recipes you're interested in."
+    CHAT_ABOUT = (
+        "Use the Chatbot tab to have a natural conversation about what you want to cook."
+        " You can describe a craving, list ingredients, or upload pictures, and the bot"
+        " will find suitable recipes."
+    )
+    HEADER_MISTRAL_DOCS = "Mistral Client Examples"
+    MISTRAL_OVERVIEW = (
+        "These examples showcase Mistral's ability to handle text, images, embeddings,"
+        " and streaming responses using the unified `Mistral` client."
+    )
+    SUBHEADER_IMAGES = "Handling Images"
+    SUBHEADER_EMBEDDINGS = "Generating Embeddings"
+    SUBHEADER_STREAMING = "Streaming Responses"
+    EXAMPLE_IMAGES = """\
+from mistralai import Mistral, UserMessage
+from mistralai.models import ImageURLChunk, TextChunk
+
+client = Mistral(api_key="YOUR_KEY")
+messages = [
+    UserMessage(content=[
+        ImageURLChunk(image_url={"url": "https://example.com/img.jpg"}),
+        TextChunk(text="What's shown here?")
+    ])
+]
+resp = client.chat.complete(model="mistral-large-latest", messages=messages)
+    """
+    EXAMPLE_EMBEDDINGS = """\
+from mistralai import Mistral
+
+client = Mistral(api_key="YOUR_KEY")
+emb = client.embeddings.create(model="mistral-embed", inputs=["hello world"])
+    """
+    EXAMPLE_STREAMING = """\
+from mistralai import Mistral, UserMessage
+
+client = Mistral(api_key="YOUR_KEY")
+for chunk in client.chat.stream(
+    model="mistral-large-latest", messages=[UserMessage(content="Hello")]
+):
+    print(chunk.data.choices[0].delta.content, end="")
+    """
+    TOOL_ARGS_INVALID = "I couldn't understand that search request."
+    EXPANDER_SEARCH_RESULTS = "Search Results"
+    COLUMN_RECIPE_TITLE = "Recipe Title"
+    COLUMN_SOURCE_URL = "Source / URL"
     ERROR_BOOK_DETAILS_NOT_FOUND = "Details not found for selected book: {label}"
     ERROR_BOOK_MISSING_DETAILS = (
         "Missing critical book details (ID, name, or local path)."

--- a/ui_pages/advanced_search.py
+++ b/ui_pages/advanced_search.py
@@ -218,8 +218,8 @@ def render_advanced_search_page(
                 df_row = {
                     "User Coverage": f"{user_cov:.1%}",
                     "Recipe Coverage": f"{recipe_cov:.1%}",
-                    "Source / URL": url,
-                    "Recipe Title": title,
+                    UiText.COLUMN_SOURCE_URL: url,
+                    UiText.COLUMN_RECIPE_TITLE: title,
                 }
                 results_data_for_df.append(df_row)
 

--- a/ui_pages/chatbot.py
+++ b/ui_pages/chatbot.py
@@ -1,0 +1,113 @@
+import base64
+import json
+import streamlit as st
+from mistralai.models import (
+    AssistantMessage,
+    UserMessage,
+    ToolMessage,
+    TextChunk,
+    ImageURLChunk,
+    SystemMessage,
+)
+
+from config import AppConfig
+from constants import ModelName, AgentText
+from chat_agent import SEARCH_TOOL, search_and_rerank
+from models import RecipeSearchArgs
+from session_state import SessionStateKeys
+from ui_helpers import UiText
+from mistral_utils import chat_complete
+
+
+def render_chatbot_page(st: st, config: AppConfig) -> None:
+    st.header(UiText.HEADER_CHAT)
+    st.info(UiText.CHAT_ABOUT)
+
+    if SessionStateKeys.CHAT_HISTORY not in st.session_state:
+        st.session_state[SessionStateKeys.CHAT_HISTORY] = [
+            SystemMessage(content=AgentText.CHATBOT_SYSTEM),
+            AssistantMessage(content=UiText.CHAT_INIT_MESSAGE),
+        ]
+
+    chat_history: list = st.session_state[SessionStateKeys.CHAT_HISTORY]
+
+    for msg in chat_history:
+        role = msg.role if msg.role != "system" else "assistant"
+        st.chat_message(role).markdown(msg.content)
+
+    uploaded_files = st.file_uploader(
+        "", type=["png", "jpg", "jpeg"], accept_multiple_files=True
+    )
+    user_input = st.chat_input(UiText.CHAT_PLACEHOLDER)
+
+    if user_input or uploaded_files:
+        content_chunks = []
+        if user_input:
+            content_chunks.append(TextChunk(text=user_input))
+        for file in uploaded_files or []:
+            b64 = base64.b64encode(file.read()).decode()
+            data_uri = f"data:image/jpeg;base64,{b64}"
+            content_chunks.append(ImageURLChunk(image_url={"url": data_uri}))
+
+        chat_history.append(UserMessage(content=content_chunks))
+
+        try:
+            response = chat_complete(
+                config,
+                messages=chat_history,
+                model=ModelName.CHAT_SMALL,
+                tools=[SEARCH_TOOL],
+                tool_choice="auto",
+            )
+        except Exception as e:
+            st.error(f"Chat API error: {e}")
+            return
+
+        msg = response.choices[0].message
+        if msg.content:
+            assistant_msg = AssistantMessage(content=msg.content)
+            chat_history.append(assistant_msg)
+            st.chat_message(assistant_msg.role).markdown(assistant_msg.content)
+
+        if msg.tool_calls:
+            tool_call = msg.tool_calls[0]
+            try:
+                args = RecipeSearchArgs.model_validate_json(tool_call.function.arguments)
+            except Exception:
+                error_msg = UiText.TOOL_ARGS_INVALID
+                assistant_error = AssistantMessage(content=error_msg)
+                chat_history.append(assistant_error)
+                st.chat_message(assistant_error.role).markdown(assistant_error.content)
+                return
+
+            results = search_and_rerank(
+                args.query,
+                config,
+                st.session_state.get(SessionStateKeys.ALL_SOURCES_LIST, []),
+            )
+            results_short = [
+                {"title": r.get("title"), "url": r.get("url")}
+                for r in results
+            ]
+            with st.sidebar.expander(UiText.EXPANDER_SEARCH_RESULTS, expanded=True):
+                for item in results_short:
+                    st.markdown(f"- [{item['title']}]({item['url']})")
+            tool_result = json.dumps(results_short)
+            chat_history.append(
+                ToolMessage(tool_call_id=tool_call.id, content=tool_result)
+            )
+            try:
+                follow = chat_complete(
+                    config,
+                    messages=chat_history,
+                    model=ModelName.CHAT_SMALL,
+                )
+            except Exception as e:
+                st.error(f"Chat API error: {e}")
+                return
+            final_msg = follow.choices[0].message
+            if final_msg.content:
+                final_assistant = AssistantMessage(content=final_msg.content)
+                chat_history.append(final_assistant)
+                st.chat_message(final_assistant.role).markdown(final_assistant.content)
+

--- a/ui_pages/mistral_doc.py
+++ b/ui_pages/mistral_doc.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+from config import AppConfig
+from ui_helpers import UiText
+
+
+def render_mistral_doc_page(st: st, config: AppConfig) -> None:
+    st.header(UiText.HEADER_MISTRAL_DOCS)
+    st.markdown(UiText.MISTRAL_OVERVIEW)
+
+    st.subheader(UiText.SUBHEADER_IMAGES)
+    st.code(UiText.EXAMPLE_IMAGES, language="python")
+
+    st.subheader(UiText.SUBHEADER_EMBEDDINGS)
+    st.code(UiText.EXAMPLE_EMBEDDINGS, language="python")
+
+    st.subheader(UiText.SUBHEADER_STREAMING)
+    st.code(UiText.EXAMPLE_STREAMING, language="python")

--- a/ui_pages/simple_search.py
+++ b/ui_pages/simple_search.py
@@ -131,8 +131,8 @@ def render_simple_search_page(st: st, config: AppConfig) -> None:
                 recipe_content_dict = r.get(RecipeKeys.RECIPE, {})
 
                 simple_df_row = {
-                    "Recipe Title": title,
-                    "Source / URL": url,
+                    UiText.COLUMN_RECIPE_TITLE: title,
+                    UiText.COLUMN_SOURCE_URL: url,
                 }
                 simple_results_data_for_df.append(simple_df_row)
 


### PR DESCRIPTION
## Summary
- introduce Mistral docs tab with API examples
- store doc text and tab name constants in `UiText`
- update chatbot agent to use `"function"` tool type
- add new tab handling in app and update tests
- simplify tests now that real Mistral package is installed

## Testing
- `python -m py_compile streamlit_app.py ui_pages/*.py constants.py session_state.py ui_helpers.py chat_agent.py models.py mistral_utils.py tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7bfb27808325814cf342c0fe3381