### PR TITLE
Fix cache dir default

### DIFF
--- a/cache_manager.py
+++ b/cache_manager.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime
 from typing import Any
 
+from constants import MiscValues
+
 import diskcache
 from models import QueryRequest, SimpleSearchRequest
 from query_top_k import (
@@ -27,7 +29,7 @@ def fetch_db_last_updated() -> datetime:
 class CacheManager:
     """Manages a persistent disk cache and invalidates on DB updates."""
 
-    def __init__(self, cache_dir: str = "recipe_cache") -> None:
+    def __init__(self, cache_dir: str = MiscValues.CACHE_DIR) -> None:
         """
         Initializes the disk cache.
 

--- a/config.py
+++ b/config.py
@@ -49,7 +49,7 @@ class AppConfig(BaseSettings):
     )
     model: ModelName = ModelName.VISION
     prompt_path: Path | None = Field(default=None)
-    cache_dir: Path | None = Field(default=None)
+    cache_dir: Path = Field(default_factory=lambda: Path(MiscValues.CACHE_DIR))
     max_log_length: int = 200
     truncation_suffix: Suffix = Suffix.ELLIPSIS
     model_config = SettingsConfigDict(

--- a/constants.py
+++ b/constants.py
@@ -138,6 +138,7 @@ class MiscValues(StrEnum):
     HTTPS_PREFIX = "https://"
     DEFAULT_NA = "N/A"
     DEFAULT_STEP = "?"
+    CACHE_DIR = "recipe_cache"
 
 
 class ConfigKeys(StrEnum):

--- a/tests/test_cache_dir.py
+++ b/tests/test_cache_dir.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+import sys
+from pathlib import Path
+import os
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.modules.setdefault("streamlit", SimpleNamespace(secrets={}))
+sys.path.insert(0, str(ROOT))
+os.environ["RECIPE_DB_PATH"] = str(ROOT / "data" / "test_recipes.db")
+
+from constants import MiscValues
+from config import AppConfig
+import cache_manager
+from diskcache import Cache
+
+
+def test_diskcache_string_none_creates_none_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    c = Cache(str(None))
+    try:
+        assert Path(c.directory).resolve() == (tmp_path / "None").resolve()
+    finally:
+        c.close()
+
+
+def test_default_cache_dir_uses_constant(monkeypatch):
+    monkeypatch.delenv("CACHE_DIR", raising=False)
+    cfg = AppConfig()
+    assert cfg.cache_dir == Path(MiscValues.CACHE_DIR)
+    cm = cache_manager.CacheManager(str(cfg.cache_dir))
+    try:
+        assert Path(cm._cache.directory).name == MiscValues.CACHE_DIR
+    finally:
+        cm.close()


### PR DESCRIPTION
## Summary
- avoid creating disk cache folders named `None`
- load default cache dir from constants
- test diskcache behaviour
- enforce constant use in CacheManager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684081ca7fdc8325a8a34b48d0dd05f0